### PR TITLE
fix for finding the template file using -t

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For an example on how this tool works see the [generator input](src/GeneratorPar
 `XamlColorSchemeGenerator` accepts the following commandline parameters:
 
 - `-g "Path_To_Your_GeneratorParameters.json"`
-- `-g "Path_To_Your_Theme.Template.xaml"`
+- `-t "Path_To_Your_Theme.Template.xaml"`
 - `-o "Path_To_Your_Output_Folder"`
 - `-v` = enables verbose console output
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "3.1.100"
+        "version": "3.1.100",
+        "rollForward": "latestMajor"
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,7 +35,7 @@
                     ? args[indexForGeneratorParametersFile] 
                     : "GeneratorParameters.json";
                 var templateFile = indexForTemplateFile > 0 && args.Length >= indexForTemplateFile
-                    ? args[indexForTemplateFile + 1] 
+                    ? args[indexForTemplateFile] 
                     : "Theme.Template.xaml";
                 var outputPath = indexForOutputPath > 0 && args.Length >= indexForOutputPath
                     ? args[indexForOutputPath]  


### PR DESCRIPTION
_I had some trouble generating the files using the command line which worked in a previous version._

I found this fixes the issue of not being able to locate the template file using the `-t` arg

(also fixed the `-g` typo in the readme)